### PR TITLE
Activate validation of codelists

### DIFF
--- a/validation.ipynb
+++ b/validation.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9f55aee9",
+   "metadata": {},
+   "source": [
+    "# Validation\n",
+    "\n",
+    "This notebook allows to easily check if a scenario conforms to the NetZero2040 project definitions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7c67806",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from workflow import main as workflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a675bf8d",
+   "metadata": {},
+   "source": [
+    "Replace `<file>` by the name of the file that you want to validate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "111f9eeb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workflow(\"<file>\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fbf3852",
+   "metadata": {},
+   "source": [
+    "If the function returns the overview of the scenario data, the validation was successful. Otherwise, please review the log."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af0cbfa5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/validation.ipynb
+++ b/validation.ipynb
@@ -45,14 +45,6 @@
    "source": [
     "If the function returns the overview of the scenario data, the validation was successful. Otherwise, please review the log."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "af0cbfa5",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/workflow.py
+++ b/workflow.py
@@ -1,5 +1,22 @@
 import pyam
+from nomenclature import DataStructureDefinition, process
+from pathlib import Path
 
-def main(df: pyam.IamDataFrame) -> pyam.IamDataFrame:   
+here = Path(__file__).absolute().parent
+
+
+def main(df: pyam.IamDataFrame) -> pyam.IamDataFrame:
+    """Project/instance-specific workflow for scenario processing"""
+
+    # Cast to an IamDataFrame if necessary
+    if not isinstance(df, pyam.IamDataFrame):
+        df = pyam.IamDataFrame(df)
+
+    # Import the codelists for the project
+    definition = DataStructureDefinition(here / "definitions")
+
+    # Validate `df` against the codelists
+    # This method raises an error if any items are not defined in the codelists.
+    definition.validate(df)
+
     return df
-  

--- a/workflow.py
+++ b/workflow.py
@@ -1,5 +1,5 @@
 import pyam
-from nomenclature import DataStructureDefinition, process
+from nomenclature import DataStructureDefinition
 from pathlib import Path
 
 here = Path(__file__).absolute().parent


### PR DESCRIPTION
I just realized that the validation of scenario data against the project codelists was not activated in `workflow.py`. This PR adds the relevant code and introduces a simple notebook to test the validation locally prior to submission to the IIASA Scenario Explorer.

fyi @sebwehrle @phackstock 