### PR TITLE
Add variables for initial AEA data submission

### DIFF
--- a/definitions/variable/energy.yaml
+++ b/definitions/variable/energy.yaml
@@ -29,6 +29,15 @@
 - Imports|{Primary Energy Carrier}:
     description: Gross imports of {Primary Energy Carrier}
     unit: TJ
+- Imports|{Primary Energy Carrier}|{Imports Source}:
+    description: Gross imports of {Primary Energy Carrier} from {Imports Source}
+    unit: TJ
 - Exports|{Primary Energy Carrier}:
     description: Gross exports of {Primary Energy Carrier}
     unit: TJ
+- Imports|Other (Diversification):
+    description: Gross imports of other energy carriers than natural gas
+      as part of the diversification away from Russian gas imports
+    unit: TJ
+    note: This variable is used in the scenario "Russia Gas Exit (April 2022)"
+      by the Austrian Energy Agency

--- a/definitions/variable/energy.yaml
+++ b/definitions/variable/energy.yaml
@@ -1,10 +1,12 @@
 - Primary Energy|{Primary Energy Carrier}:
     description: Primary energy consumption of {Primary Energy Carrier}
     unit: TJ
+    note: should be equal to 'Domestic Production' + 'Imports' - 'Exports'
 - Secondary Energy|Electricity|{Electricity Input}:
     description: Total net generation of electricity from {Electricity Input}
       (including transmission losses)
     unit: TJ
+    note: this is equivalent to "Conversion Output"
 - Conversion Input|Electricity|{Electricity Input}:
     description: Consumption of {Electricity Input} for electricity generation
       (including transmission losses)
@@ -20,4 +22,13 @@
 - Final Energy|{Sector}|{Final Energy Carrier}:
     description: Final consumption of {Final Energy Carrier} by {Sector}
       (excluding transmission/distribution losses)
+    unit: TJ
+- Domestic Production|{Primary Energy Carrier}:
+    description: Domestic production of {Primary Energy Carrier}
+    unit: TJ
+- Imports|{Primary Energy Carrier}:
+    description: Gross imports of {Primary Energy Carrier}
+    unit: TJ
+- Exports|{Primary Energy Carrier}:
+    description: Gross exports of {Primary Energy Carrier}
     unit: TJ

--- a/definitions/variable/tag_import_source.yaml
+++ b/definitions/variable/tag_import_source.yaml
@@ -1,0 +1,5 @@
+- Imports Source:
+    - Russia:
+        description: Russia
+    - Other:
+        description: other countries

--- a/definitions/variable/tag_import_source.yaml
+++ b/definitions/variable/tag_import_source.yaml
@@ -3,3 +3,4 @@
         description: Russia
     - Other:
         description: other countries
+ 


### PR DESCRIPTION
This PR adds variables needed to process data provided by the AEA: Energy Balances, Ruxit, and gGAS.