### PR TITLE
add nomenclature level for plant type

### DIFF
--- a/definitions/variable/capacity.yaml
+++ b/definitions/variable/capacity.yaml
@@ -13,7 +13,7 @@
 - Capacity|Storage|Level|Electricity|{Electricity Storage Types}:
     description: Capacity to store electrical energy
     unit: GWh
-- Capacity|Storage|Charging|Electricity|{Electrictiy Storage Types}:
+- Capacity|Storage|Charging|Electricity|{Electricity Storage Types}:
     description: Installed capacity to charge electricity storage
     unit: MW
 - Capacity|Storage|Discharging|Electricity|{Electricity Storage Types}:

--- a/definitions/variable/capacity.yaml
+++ b/definitions/variable/capacity.yaml
@@ -9,3 +9,4 @@
     unit: MW
 - Capacity|Electrolyzer|Hydrogen|Electricity:
     description: Installed capacity to generate hydrogen from electricity
+    unit: MW

--- a/definitions/variable/capacity.yaml
+++ b/definitions/variable/capacity.yaml
@@ -1,3 +1,11 @@
-- Capacity|Electricity|{Electricity Input}:
+- Capacity|Power Plant|Electricity|{Electricity Input}:
     description: Installed capacity to generate electricity from {Electricity Input}
     unit: MW
+- Capacity|Combined Heat and Power Plant|Electricity|{Electricity Input}:
+    description: Installed capacity to co-generate electricity from {Electricity Input}
+    unit: MW
+- Capacity|Heat Plant|Heat|{Electricity Input}:
+    description: Installed capacity to generate electricity from {Electricity Input}
+    unit: MW
+- Capacity|Electrolyzer|Hydrogen|Electricity:
+    description: Installed capacity to generate hydrogen from electricity

--- a/definitions/variable/capacity.yaml
+++ b/definitions/variable/capacity.yaml
@@ -7,6 +7,24 @@
 - Capacity|Heat Plant|Heat|{Electricity Input}:
     description: Installed capacity to generate electricity from {Electricity Input}
     unit: MW
-- Capacity|Electrolyzer|Hydrogen|Electricity:
+- Capacity|Storage|Electricity|Hydro|Pumped:
+    description: Installed capacity to generate electricity from {Electricity Input}
+    unit: MW
+- Capacity|Storage|Electricity|Hydro|Reservoir:
+    description: Installed capacity to generate electricity from {Electricity Input}
+    unit: MW
+- Capacity|Storage|Electricity|Battery:
+    description: Installed capacity to generate electricity from {Electricity Input}
+    unit: MW
+- Capacity|Storage|Heat:
+    description: Installed capacity to generate electricity from {Electricity Input}
+    unit: MW
+- Capacity|Storage|CO2:
+    description: Installed capacity to generate electricity from {Electricity Input}
+    unit: MW
+- Capacity|Storage|Hydrogen:
+    description: Installed capacity to generate electricity from {Electricity Input}
+    unit: MW
+- Capacity|P2G|Hydrogen|Electricity:
     description: Installed capacity to generate hydrogen from electricity
     unit: MW

--- a/definitions/variable/capacity.yaml
+++ b/definitions/variable/capacity.yaml
@@ -4,27 +4,37 @@
 - Capacity|Combined Heat and Power Plant|Electricity|{Electricity Input}:
     description: Installed capacity to co-generate electricity from {Electricity Input}
     unit: MW
-- Capacity|Heat Plant|Heat|{Electricity Input}:
-    description: Installed capacity to generate electricity from {Electricity Input}
+- Capacity|Heat Plant|Heat|{Heat Input}:
+    description: Installed capacity to generate heat from {Heat Input}
     unit: MW
-- Capacity|Storage|Electricity|Hydro|Pumped:
-    description: Installed capacity to generate electricity from {Electricity Input}
-    unit: MW
-- Capacity|Storage|Electricity|Hydro|Reservoir:
-    description: Installed capacity to generate electricity from {Electricity Input}
-    unit: MW
-- Capacity|Storage|Electricity|Battery:
-    description: Installed capacity to generate electricity from {Electricity Input}
-    unit: MW
-- Capacity|Storage|Heat:
-    description: Installed capacity to generate electricity from {Electricity Input}
-    unit: MW
-- Capacity|Storage|CO2:
-    description: Installed capacity to generate electricity from {Electricity Input}
-    unit: MW
-- Capacity|Storage|Hydrogen:
-    description: Installed capacity to generate electricity from {Electricity Input}
-    unit: MW
-- Capacity|P2G|Hydrogen|Electricity:
+- Capacity|Electrolyser|Hydrogen|Electricity:
     description: Installed capacity to generate hydrogen from electricity
     unit: MW
+- Capacity|Storage|Level|Electricity|{Electricity Storage Types}:
+    description: Capacity to store electrical energy
+    unit: GWh
+- Capacity|Storage|Charging|Electricity|{Electrictiy Storage Types}:
+    description: Installed capacity to charge electricity storage
+    unit: MW
+- Capacity|Storage|Discharging|Electricity|{Electricity Storage Types}:
+    description: Installed capacity to discharge electricity storage
+    unit: MW
+- Capacity|Storage|Level|Heat|{Heat Storage Types}:
+    description: Capacity to store heat energy
+    unit: GWh
+- Capacity|Storage|Charging|Heat|{Heat Storage Types}:
+    description: Installed capacity to charge heat storage
+    unit: MW
+- Capacity|Storage|Discharging|Heat|{Heat Storage Types}:
+    description: Installed capacity to discharge heat storage
+    unit: MW
+- Capacity|Storage|Level|Hydrogen|{Hydrogen Storage Types}:
+    description: (Energy-equivalent) capacity to store hydrogen
+    unit: GWh
+- Capacity|Storage|Charging|Hydrogen|{Hydrogen Storage Types}:
+    description: (Energy-equivalent) capacity to charge hydrogen storage
+    unit: MW
+- Capacity|Storage|Discharging|Hydrogen|{Hydrogen Storage Types}:
+    description: (Energy-equivalent) capacity to discharge hydrogen storage
+    unit: MW
+

--- a/definitions/variable/energy.yaml
+++ b/definitions/variable/energy.yaml
@@ -6,9 +6,10 @@
       (including transmission losses)
     unit: TJ
 - Secondary Energy|Heat|{Heat Input}:
-    description: Total net generation of electricity from {Electricity Input}
+    description: Total net generation of heat from {Heat Input}
       (including transmission losses)
     unit: TJ
+    note: this is equivalent to "Conversion Output"
 - Conversion Input|Electricity|{Electricity Input}:
     description: Consumption of {Electricity Input} for electricity generation
       (including transmission losses)

--- a/definitions/variable/energy.yaml
+++ b/definitions/variable/energy.yaml
@@ -5,6 +5,10 @@
     description: Total net generation of electricity from {Electricity Input}
       (including transmission losses)
     unit: TJ
+- Secondary Energy|Heat|{Heat Input}:
+    description: Total net generation of electricity from {Electricity Input}
+      (including transmission losses)
+    unit: TJ
 - Conversion Input|Electricity|{Electricity Input}:
     description: Consumption of {Electricity Input} for electricity generation
       (including transmission losses)

--- a/definitions/variable/power_plant.yaml
+++ b/definitions/variable/power_plant.yaml
@@ -5,6 +5,6 @@
 - Inflows|Electricity|Hydro|Pumped:
     description: (energy-equivalent) inflows of water into reservoirs of pumped hydro
     unit: GWh
-- Inflows|Electricity|Hydro|Hydro:
+- Inflows|Electricity|Hydro|Reservoir:
     description: (energy-equivalent) inflows of water into hydro reservoirs
     unit: GWh

--- a/definitions/variable/power_plant.yaml
+++ b/definitions/variable/power_plant.yaml
@@ -1,0 +1,10 @@
+# List of variables related to power plant attributes
+- Inflows|Electricity|Hydro:
+    description: (energy-equivalent) inflows of water into hydro storages
+    unit: GWh
+- Inflows|Electricity|Hydro|Pumped:
+    description: (energy-equivalent) inflows of water into reservoirs of pumped hydro
+    unit: GWh
+- Inflows|Electricity|Hydro|Hydro:
+    description: (energy-equivalent) inflows of water into hydro reservoirs
+    unit: GWh

--- a/definitions/variable/tag_electricity.yaml
+++ b/definitions/variable/tag_electricity.yaml
@@ -17,8 +17,14 @@
         description: Coal gases
     - Gas|Hydrogen:
         description: Hydrogen
+    - Gas|Synthetic Gas:
+        description: Synthetically produced methane
+    - Gas|Synthetic Gas|Green Methane:
+        description: Synthetically produced methane from renewable sources
+    - Gas|Synthetic Gas|Other Methane:
+        description: Synthtically produced methane from non-renewable sources
     - Gas|Biogas:
-        description: Gas from biogenic sources
+        description: Gas from biogenic sources (lower energy content than methane)
     - Biomass:
         description: Solid biomass
     - Hydro:

--- a/definitions/variable/tag_electricity.yaml
+++ b/definitions/variable/tag_electricity.yaml
@@ -42,8 +42,8 @@
         description: Run-of-river hydropower
     - Hydro|Reservoir:
         description: Reservoir-storage hydropower
-    - Hydro|Reservoir Inflows:
-        description: Inflows of water into hydro reservoirs incl. pumped storages
+    - Hydro|Pumped Storage:
+        description: Pumped storage hydro power
     - Solar:
         description: Solar energy
     - Wind:

--- a/definitions/variable/tag_electricity_storage_types.yaml
+++ b/definitions/variable/tag_electricity_storage_types.yaml
@@ -1,0 +1,9 @@
+- Electricity Storage Types:
+    - Hydro:
+        description: electric power plant using water for energy storage
+    - Hydro|Pumped:
+        description: pumped hydro storage plant
+    - Hydro|Reservoir:
+        description: hydro reservoir storage plant
+    - Battery:
+        description: battery storage

--- a/definitions/variable/tag_final_energy.yaml
+++ b/definitions/variable/tag_final_energy.yaml
@@ -29,6 +29,12 @@
         description: Methane from biogenic sources
     - Gas|Hydrogen:
         description: Hydrogen
+    - Gas|Synthetic Gas:
+        description: Synthetically produced methane
+    - Gas|Synthetic Gas|Green Methane:
+        description: Synthetically produced methane from renewable sources
+    - Gas|Synthetic Gas|Other Methane:
+        description: Synthtically produced methane from non-renewable sources
     - Electricity:
         description: Electricity
     - Solar:

--- a/definitions/variable/tag_heat.yaml
+++ b/definitions/variable/tag_heat.yaml
@@ -1,6 +1,6 @@
-- Electricity Input:
-    - Coal:
-        description: Anthracite, coking coal, lignite, peat
+- Heat Input:
+    - Electricity:
+        description: Electricity
     - Liquids:
         description: Liquid fuels
     - Liquids|Fossil:
@@ -27,18 +27,8 @@
         description: Gas from biogenic sources (lower energy content than methane)
     - Biomass:
         description: Solid biomass
-    - Hydro:
-        description: Hydropower
-    - Hydro|Run of River:
-        description: Run-of-river hydropower
-    - Hydro|Reservoir:
-        description: Reservoir-storage hydropower
-    - Hydro|Reservoir Inflows:
-        description: Inflows of water into hydro reservoirs incl. pumped storages
     - Solar:
         description: Solar energy
-    - Wind:
-        description: Wind
     - Geothermal:
         description: Geothermal energy
     - Waste:

--- a/definitions/variable/tag_heat_storage_types.yaml
+++ b/definitions/variable/tag_heat_storage_types.yaml
@@ -1,5 +1,5 @@
 - Heat Storage Types:
-    - Hot water tank:
+    - Hot Water Tank:
         description: large-scale hot water tank in district heating systems
     - Pit storage:
         description: large-scale pit thermal energy storage for district heating

--- a/definitions/variable/tag_heat_storage_types.yaml
+++ b/definitions/variable/tag_heat_storage_types.yaml
@@ -1,0 +1,5 @@
+- Heat Storage Types:
+    - Hot water tank:
+        description: large-scale hot water tank in district heating systems
+    - Pit storage:
+        description: large-scale pit thermal energy storage for district heating

--- a/definitions/variable/tag_heat_storage_types.yaml
+++ b/definitions/variable/tag_heat_storage_types.yaml
@@ -1,5 +1,5 @@
 - Heat Storage Types:
     - Hot Water Tank:
         description: large-scale hot water tank in district heating systems
-    - Pit storage:
+    - Pit Storage:
         description: large-scale pit thermal energy storage for district heating

--- a/definitions/variable/tag_hydrogen_storage_types.yaml
+++ b/definitions/variable/tag_hydrogen_storage_types.yaml
@@ -1,0 +1,7 @@
+- Hydrogen Storage Types:
+    - Hydrogen Storage Tank:
+        description: large-scale pressurized storage tank
+    - LOHC Compounds:
+        description: liquid organic hydrogen carriers
+    - Cavern:
+        description: large-scale underground storage

--- a/definitions/variable/utilisation.yaml
+++ b/definitions/variable/utilisation.yaml
@@ -1,0 +1,9 @@
+- Utilisation|Combined Heat and Power|Electricity|{Electricity Input}:
+    description: utilisation / full load hours of CHP plants producing electricity from {Electricity Input}
+    unit: h/a
+- Utilisation|Power Plant|Electricity|{Electricity Input}:
+    description: utilisation / full load hours of power plants producing electricity from {Electricity Input}
+    unit: h/a
+- Utilisation|Heat Plant|Heat|{Heat Input}:
+    description: utilisation / full load hours of heat plants producing heat from {Electricity Input}
+    unit: h/a


### PR DESCRIPTION
We need to add a plant-type descriptor to uniquely identify plant capacities and facilitate exchange between TIMES and medea. Without the additional descriptor, it is unclear whether Capacity|Electricity|{Electricity Input} refers to CHP capacity. 