### PR TITLE
Add variable for ETS & sectoral CO2 emissions

### DIFF
--- a/definitions/variable/emissions.yaml
+++ b/definitions/variable/emissions.yaml
@@ -7,3 +7,17 @@
 - Emissions|CO2|{Sector}:
     description: Net CO2 emissions from {Sector}
     unit: Mt CO2/yr
+
+- Emissions|CH4:
+    description: Methane emissions
+    unit: Mt CH4/yr
+- Emissions|CH4|{Sector}:
+    description: Methane emissions from {Sector}
+    unit: Mt CH4/yr
+
+- Emissions|N2O:
+    description: Nitrous oxide emissions
+    unit: Mt N2O/yr
+- Emissions|N2O|{Sector}:
+    description: Nitrous oxide emissions from {Sector}
+    unit: Mt N2O/yr

--- a/definitions/variable/emissions.yaml
+++ b/definitions/variable/emissions.yaml
@@ -1,0 +1,9 @@
+- Emissions|CO2:
+    description: Net CO2 emissions
+    unit: Mt CO2/yr
+- Emissions|CO2|{ETS}:
+    description: Net CO2 emissions from all sources in sectors {ETS}
+    unit: Mt CO2/yr
+- Emissions|CO2|{Sector}:
+    description: Net CO2 emissions from {Sector}
+    unit: Mt CO2/yr

--- a/definitions/variable/tag_ets.yaml
+++ b/definitions/variable/tag_ets.yaml
@@ -1,0 +1,9 @@
+- ETS:
+    - EU-ETS:
+        description: covered by the European Union Emissions Trading System (EU ETS)
+        weight: EU-ETS
+    - Non-EU-ETS:
+        description: covered by the European Effort Sharing Regulation directive (ESR)
+        note: This category includes sectors not covered by the EU ETS,
+          including emissions from land use, land use change, and forestry.
+        weight: Non-EU-ETS


### PR DESCRIPTION
This PR implements one aspect of #18: CO2 emissions by ETS/non-ETS and at the sectoral level.

cc @ClaKet

Two questions:
- We could add an additional hierarchy-level like `Emissions|CO2|{Sector}|{Final Energy Carrier}
- We could add an additional variable `Gross Emissions|CO2` (and subcategories) to clearly differentiate between the amount of CO2 released to the atmosphere versus CO2 captured in a sector, see this usage in the openentrance project [here](https://github.com/openENTRANCE/openentrance/blob/2e8e348d0903bc19257eeacd639dd0cb881c98bc/definitions/variable/emissions/emissions.yaml#L448)

Of course, both additions could be implemented later...