### PR TITLE
Add final-energy variables for non-energy use

### DIFF
--- a/definitions/variable/energy.yaml
+++ b/definitions/variable/energy.yaml
@@ -47,6 +47,19 @@
     unit: TJ
     note: This variable is the lower bound of this fuel in the energy mix of a scenario.
       It is used in the study "Green Gas (June 2021)" by the Austrian Energy Agency.
+- Final Energy|Non-Energy Use:
+    description: Final energy consumption in non-combustion processes
+    unit: EJ/yr
+- Final Energy|Non-Energy Use|{Final Energy Carrier}:
+    description: Final energy consumption of {Final Energy Carrier} in non-combustion processes
+    unit: EJ/yr
+- Final Energy|Non-Energy Use|{Non-Energy Sector}:
+    description: Final energy consumption by the {Non-Energy Sector} for non-combustion processes
+    unit: EJ/yr
+- Final Energy|Non-Energy Use|{Non-Energy Sector}|{Final Energy Carrier}:
+    description: Final energy consumption of {Final Energy Carrier} by the {Non-Energy Sector}
+      for non-combustion processes
+    unit: EJ/yr
 - Transmission Losses|{Network-Based Energy Carriers}:
     description: Transmission losses of {Network-Based Energy Carriers}
     unit: TJ

--- a/definitions/variable/tag_non_energy_sectors.yaml
+++ b/definitions/variable/tag_non_energy_sectors.yaml
@@ -1,0 +1,13 @@
+- Non-Energy Sector:
+    - Iron and Steel:
+        description: iron and steel sector
+    - Non-Ferrous Metals:
+        description: non-ferrous metals sector
+    - Non-Metallic Minerals:
+        description: non-metallic minerals sector
+    - Chemicals:
+        description: chemical sector
+    - Pulp and Paper:
+        description: pulp and paper sector
+    - Other Sector:
+        description: other industries


### PR DESCRIPTION
This PR adds variables for non-energy use in industrial sectors. It follows the conventions of the IAMC-common-defintions repository, see [here](https://github.com/IAMconsortium/common-definitions/blob/main/definitions/variable/energy/tag_non_energy_sectors.yaml).